### PR TITLE
Fix gdbus-codegen command-line interface

### DIFF
--- a/cmake/gdbus_codegen.cmake
+++ b/cmake/gdbus_codegen.cmake
@@ -28,7 +28,7 @@ function (generate_gdbus_code)
   add_custom_command (
     OUTPUT "${ARG_OUTPUT}.c" "${ARG_OUTPUT}.h"
     COMMAND ${GDBUS_CODEGEN} --generate-c-code "${ARG_OUTPUT}"
-                             --interface "${ARG_INTERFACE}"
+                             --interface-prefix "${ARG_INTERFACE}"
                              ${GDBUS_OPTIONS}
                              "${ARG_INPUT}"
     MAIN_DEPENDENCY "${ARG_INPUT}"


### PR DESCRIPTION
Previously, running `cmake . && make` would result in the following error:

```
usage: gdbus-codegen [-h] [--interface-prefix PREFIX]
                     [--c-namespace NAMESPACE] [--c-generate-object-manager]
                     [--c-generate-autocleanup {none,objects,all}]
                     [--generate-docbook OUTFILES] [--pragma-once]
                     [--annotate WHAT KEY VALUE WHAT KEY VALUE WHAT KEY VALUE]
                     [--generate-c-code OUTFILES | --header | --body | --interface-info-header | --interface-info-body]
                     [--output FILE | --output-directory OUTDIR]
                     [FILE [FILE ...]]
gdbus-codegen: error: ambiguous option: --interface could match --interface-prefix, --interface-info-header, --interface-info-body
```

This patch fixes that so it is no longer ambiguous.