### PR TITLE
Enable setting browser manifests install location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,15 +6,15 @@ option (ENABLE_CHROME "Install manifest for Google Chrome" ON)
 option (ENABLE_CHROMIUM "Install manifest for Chromium" ON)
 
 option (INSTALL_FOR_CURRENT_USER "Install for current user only" OFF)
+set (CHROMIUM_MANIFEST_DESTINATION "/etc/chromium/native-messaging-hosts" CACHE STRING "Choromium's manifest installation location")
+set (CHROME_MANIFEST_DESTINATION "/etc/opt/chrome/native-messaging-hosts" CACHE STRING "Chrome's manifest installation location")
+set (FIREFOX_MANIFEST_DESTINATION "/usr/lib/mozilla/native-messaging-hosts" CACHE STRING "Firefox's manifest installation location")
+set (CMAKE_INSTALL_PREFIX "/usr/local" CACHE STRING "Install prefix")
 
 if (INSTALL_FOR_CURRENT_USER)
   set (CHROMIUM_MANIFEST_DESTINATION "$ENV{HOME}/.config/chromium/NativeMessagingHosts")
   set (CHROME_MANIFEST_DESTINATION "$ENV{HOME}/.config/google-chrome/NativeMessagingHosts")
   set (FIREFOX_MANIFEST_DESTINATION "$ENV{HOME}/.mozilla/native-messaging-hosts")
-else ()
-  set (CHROMIUM_MANIFEST_DESTINATION "/etc/chromium/native-messaging-hosts")
-  set (CHROME_MANIFEST_DESTINATION "/etc/opt/chrome/native-messaging-hosts")
-  set (FIREFOX_MANIFEST_DESTINATION "/usr/lib/mozilla/native-messaging-hosts")
 endif ()
 
 


### PR DESCRIPTION
[I'm trying to package wmc-mpris in NixOS](https://github.com/NixOS/nixpkgs/pull/64891). We are having trouble with the hardcoded `/etc/chromium` and other locations written in `CMakeLists.txt`. This Change enables us to elegantly [use our own prefix](https://nixos.org/nixpkgs/manual/#build-phase) and having the native-messaging-hosts json files point to the right location of the executables.

I don't think it affects the current behaviour. If you are willing to merge this, I'll add a commit that updates the README accordingly.

Thanks.